### PR TITLE
Migrate to Slick 2.1.0 and Scala 2.11.6.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,14 +29,6 @@ This implementation guarantees (if no bugs) that:
 
 Also an app can check that the code it uses matches the database schema version, so it does not run with incompatible versions.
 
-Requirements: Building Slick
------------------------------------------------------------------------
-This project was tested against a Slick revision which has not been released in binary form. You need build it yourself and publish it locally. To do this:
-
-- ``git clone git@github.com:slick/slick.git``
-- ``git checkout d84799440894370af14f06969dff5a354496bf55``
-- ``sbt publish-local`` (You may have to configure the sbt-gpg plugin or gpg for this to work. Good luck :))
-
 Getting started / Demo
 -----------------------------------------------------------------------
 Demo steps (simplified output shown here; run ``run help`` for command descriptions)

--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,15 @@ name := "slick-migrations"
 
 version := "1.0"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.11.6"
 
 scalacOptions += "-deprecation"
 
 scalacOptions += "-feature"
 
 libraryDependencies ++= List(
-  "com.typesafe.slick" % "slick_2.10.0" % "1.1.0-SNAPSHOT"
-  ,"org.scala-lang" % "scala-compiler" % "2.10.0"
+  "com.typesafe.slick" %% "slick" % "2.1.0"
+  ,"org.scala-lang" % "scala-compiler" % "2.11.6"
   ,"com.h2database" % "h2" % "1.3.166"
   ,"org.xerial" % "sqlite-jdbc" % "3.6.20"
   ,"org.slf4j" % "slf4j-nop" % "1.6.4" // <- disables logging

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.0
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")

--- a/src/main/scala/App.scala
+++ b/src/main/scala/App.scala
@@ -1,6 +1,6 @@
 import scala.slick.migrations._
 import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
+import Database.dynamicSession
 object App{
   def run(mm:MyMigrationManager){
 /*
@@ -12,7 +12,7 @@ object App{
     }
     println("Users in the database:")
     println(
-      mm.db.withSession{
+      mm.db.withDynSession{
         Users.map(u=>u).list
       }
     )

--- a/src/main/scala/SampleCodegen.scala
+++ b/src/main/scala/SampleCodegen.scala
@@ -4,10 +4,10 @@ import scala.slick.jdbc.JdbcBackend
 import scala.slick.driver.H2Driver
 import scala.slick.driver.H2Driver.simple._
 import scala.slick.migrations._
-import Database.threadLocalSession
+import Database.dynamicSession
 object SampleCodegen{
   def gen(mm:MyMigrationManager){
-    mm.db withSession {
+    mm.db withDynSession {
       if(mm.notYetAppliedMigrations.size > 0){
         println("Your database is not up to date, code generation denied for compatibility reasons. Please update first.")
         return

--- a/src/main/scala/Tool.scala
+++ b/src/main/scala/Tool.scala
@@ -33,9 +33,9 @@ object Tool extends App{
       SampleCodegen.gen( SampleMigrations ) // SampleMigrations is passed in here only because it contains the db connection
     case "dbdump" :: Nil =>
       import scala.slick.driver.H2Driver.simple._
-      import Database.threadLocalSession
+      import Database.dynamicSession
       import scala.slick.jdbc.StaticQuery._
-      SampleMigrations.db.withSession{
+      SampleMigrations.db.withDynSession{
         println( queryNA[String]("SCRIPT").list.mkString("\n") )
       }
     case "app" :: Nil =>

--- a/src/main/scala/scala/slick/jdbc/meta/CodeGen.scala
+++ b/src/main/scala/scala/slick/jdbc/meta/CodeGen.scala
@@ -16,8 +16,8 @@ object CodeGen {
       if(columns.tail.isEmpty) s = s + (scalaTypeFor(columns.head))
       else s = s + ("(" + columns.map(c => scalaTypeFor(c)).mkString(", ") + ")")
       s = s + ("](\""+table.name.name+"\") {") + "\n"
-      for(c <- columns) s = s + output2(c, pkeys.get(c.column))
-      s = s + ("  def * = " + columns.map(c => mkScalaName(c.column, false)).mkString(" ~ ")) + "\n"
+      for(c <- columns) s = s + output2(c, pkeys.get(c.name))
+      s = s + ("  def * = " + columns.map(c => mkScalaName(c.name, false)).mkString(" ~ ")) + "\n"
       s = s + ("}") + "\n"
     }
     s
@@ -26,10 +26,10 @@ object CodeGen {
 
   def output2(c: MColumn, pkey: Option[MPrimaryKey])(implicit session: JdbcBackend#Session) : String = {
     var s = ""
-    s = s + ("  def "+mkScalaName(c.column, false)+" = column["+scalaTypeFor(c)+"](\""+c.column+"\"")
+    s = s + ("  def "+mkScalaName(c.name, false)+" = column["+scalaTypeFor(c)+"](\""+c.name+"\"")
     for(n <- c.sqlTypeName) {
       s = s + (", O DBType \""+n+"")
-      for(i <- c.columnSize ) s = s + ("("+i+")")
+      for(i <- c.size ) s = s + ("("+i+")")
       s = s + ("\"")
     }
     if(c.isAutoInc.getOrElse(false)) s = s + (", O AutoInc")
@@ -45,17 +45,17 @@ object CodeGen {
       if(columns.tail.isEmpty) out.print(scalaTypeFor(columns.head))
       else out.print("(" + columns.map(c => scalaTypeFor(c)).mkString(", ") + ")")
       out.println("](\""+table.name.name+"\") {")
-      for(c <- columns) output(c, pkeys.get(c.column), out)
-      out.println("  def * = " + columns.map(c => mkScalaName(c.column, false)).mkString(" ~ "))
+      for(c <- columns) output(c, pkeys.get(c.name), out)
+      out.println("  def * = " + columns.map(c => mkScalaName(c.name, false)).mkString(" ~ "))
       out.println("}")
     }
   }
 
   def output(c: MColumn, pkey: Option[MPrimaryKey], out: PrintWriter)(implicit session: JdbcBackend#Session) {
-    out.print("  def "+mkScalaName(c.column, false)+" = column["+scalaTypeFor(c)+"](\""+c.column+"\"")
+    out.print("  def "+mkScalaName(c.name, false)+" = column["+scalaTypeFor(c)+"](\""+c.name+"\"")
     for(n <- c.sqlTypeName) {
       out.print(", O DBType \""+n+"")
-      for(i <- c.columnSize ) out.print("("+i+")")
+      for(i <- c.size ) out.print("("+i+")")
       out.print("\"")
     }
     if(c.isAutoInc.getOrElse(false)) out.print(", O AutoInc")

--- a/src/main/scala/scala/slick/jdbc/reflect/reflect.scala
+++ b/src/main/scala/scala/slick/jdbc/reflect/reflect.scala
@@ -28,12 +28,12 @@ class Column(val table:Table,val column:MColumn)(implicit session:JdbcBackend#Se
   val t = table
   val c = column
   def _value = (t,c) 
-  def name = c.column
+  def name = c.name
   def autoInc = c.isAutoInc
   def primaryKey = t.primaryKey.contains(this)
   def nullable = c.nullable // FIXME: what is the difference between nullable and isNullable?
   def sqlType = c.sqlType
   def sqlTypeName = c.sqlTypeName // <- shouldn't this go into the code generator?
-  def columnSize = c.columnSize
+  def columnSize = c.size
   override def toString = s"Column(${name})"
 }

--- a/src/main/scala/scala/slick/migrations/MigrationsMacros.scala
+++ b/src/main/scala/scala/slick/migrations/MigrationsMacros.scala
@@ -1,10 +1,10 @@
 package scala.slick.migrations
 import scala.slick.driver.H2Driver.simple._
-import Database.threadLocalSession
+import Database.dynamicSession
 import scala.language.experimental.macros
 
 abstract class GenericMigration[T]( val id:T )(f : Session => Unit) extends Migration[T]{
-  def up : Unit = f(threadLocalSession)
+  def up : Unit = f(dynamicSession)
   def code : String
 }
 


### PR DESCRIPTION
The demo is a bit outdated, and is especially troublesome for Java 8 users (using Scala 2.10 and Java 8 will result in some compilation errors). Updating this to make it runnable with Slick 2.1 and Scala 2.11 will make it much more convenient for others users to play with.

I've updated the Scala, sbt, and Slick versions to the latest, and made some changes to the code correspondingly. For now, it looks fine by walking through the demo procedures.
